### PR TITLE
fix: prevent browser autofill from token field

### DIFF
--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -54,6 +54,7 @@ export const ConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
             label="Token"
             placeholder="Token"
             value={options.secureJsonData?.accessToken}
+            autoComplete="new-password"
             onChange={(event) =>
               onOptionsChange({
                 ...options,


### PR DESCRIPTION
Chrome's (and other browser's) autofill will fill in the token field with the Grafana password if you have it saved. [`new-password` is signal](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#preventing_autofilling_with_autocompletenew-password) that most browser's respect to _not_ autofill the password.

Closes #40 