### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+- Bug: TLS option are now correctly passed to the LogScale client.
+
 ## 1.0.0
 
 - Documentation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-falconlogscale-datasource",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Falcon LogScale data source plugin for Grafana",
   "scripts": {
     "build": "rm -rf node_modules/@grafana/data/node_modules; grafana-toolkit plugin:build",


### PR DESCRIPTION
1.0.1

- Bug: TLS option are now correctly passed to the LogScale client.