### PR TITLE
Add Docker image builds and post `docker pull` commands for local testing

### DIFF
--- a/.github/workflows/pull-request-image.yml
+++ b/.github/workflows/pull-request-image.yml
@@ -1,0 +1,111 @@
+name: Create Docker image for local testing
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  build:
+    name: Build and archive plugin build artifacts
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install Go environment
+        uses: actions/setup-go@v4
+
+      - name: Install yarn dependencies
+        run: yarn install
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Build Frontend
+        run: yarn build
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
+
+      - name: Archive plugin build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: plugin-dist
+          path: |
+            dist
+          retention-days: 1
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download plugin build artifacts
+        uses: actions/download-artifact@v3
+        id: download
+        with:
+          name: plugin-dist
+
+      - name: Generate Dockerfile
+        shell: bash
+        run: |
+          echo "FROM grafana/grafana-oss:latest
+
+          # Make it as simple as possible to access the grafana instance for development purposes
+          # Do NOT enable these settings in a public facing / production grafana instance
+          ENV GF_AUTH_ANONYMOUS_ORG_ROLE "Admin"
+          ENV GF_AUTH_ANONYMOUS_ENABLED "true"
+          ENV GF_AUTH_BASIC_ENABLED "false"
+
+          # Set development mode so plugins can be loaded without the need to sign
+          ENV GF_DEFAULT_APP_MODE "development"
+
+          # TODO: Cleanup script should remove images from closed PRs using these labels
+          LABEL gh-sha="${{ github.event.pull_request.head.sha }}"
+          LABEL gh-repo="${{ github.event.repository.name }}"
+          LABEL gh-pr-number="${{ github.event.number }}"
+
+          # Copy plugin build artifacts into the image
+          COPY . /var/lib/grafana/plugins/${{ github.event.repository.name }}/" > Dockerfile
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: grafana/plugin-builds:${{ github.event.pull_request.head.sha }}pre
+  add_pr_comment:
+    name: Add PR comment
+    runs-on: ubuntu-latest
+    needs: push_to_registry
+    steps:
+      - name: Add comment to PR
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            Use the following command to run this PR with Docker at http://localhost:3000:
+
+              ```
+              docker run --rm -p 3000:3000 grafana/plugin-builds:${{ github.event.pull_request.head.sha }}pre
+              ```


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/issues/73287.

This PR gives us the ability to just spin up a Docker image to test any changes made in a local instance of Grafana. When the CI pipeline is complete, the Github Actions bot will publish a helpful PR comment so that the reviewer can just copy/paste the command into their terminal.

The image is tagged with the long SHA of the most recent commit. At least in the short-term, all plugins will push to the same Docker Hub repo, so we use the long SHA to minimise the possibility of collision (it's also much easier to get that from the build context than the short SHA).