### PR TITLE
Update query editor

### DIFF
--- a/src/components/LogScaleQueryEditor.tsx
+++ b/src/components/LogScaleQueryEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
-import { Select, QueryField, InlineFormLabel } from '@grafana/ui';
+import { Select, QueryField } from '@grafana/ui';
+import { EditorRows, EditorRow, EditorField } from '@grafana/experimental';
 import { DataSource } from '../DataSource';
 import { LogScaleOptions, LogScaleQuery } from './../types';
 import { parseRepositoriesResponse } from '../utils/utils';
@@ -25,10 +26,9 @@ export function LogScaleQueryEditor(props: Props) {
   }, [datasource, onChange, query]);
 
   return (
-    <div className="query-editor-row">
-      <div className="gf-form-inline gf-form-inline--nowrap">
-        <div className="gf-form gf-form--grow flex-shrink-1">
-          <InlineFormLabel width={6}>Query</InlineFormLabel>
+    <EditorRows>
+      <EditorRow>
+        <EditorField label="Query" width={'100%'}>
           <QueryField
             query={query.lsql}
             onChange={(val) => onChange({ ...query, lsql: val })}
@@ -36,18 +36,18 @@ export function LogScaleQueryEditor(props: Props) {
             placeholder="Enter a LogScale query (run with Shift+Enter)"
             portalOrigin="LogScale"
           />
-        </div>
-      </div>
-
-      <div className="gf-form gf-form--grow flex-shrink-1">
-        <InlineFormLabel width={6}>Repository</InlineFormLabel>
-        <Select
-          width={30}
-          options={repositories}
-          value={query.repository}
-          onChange={(val) => onChange({ ...query, repository: val.value!.toString() })}
-        />
-      </div>
-    </div>
+        </EditorField>
+      </EditorRow>
+      <EditorRow>
+        <EditorField label="Repository">
+          <Select
+            width={30}
+            options={repositories}
+            value={query.repository}
+            onChange={(val) => onChange({ ...query, repository: val.value!.toString() })}
+          />
+        </EditorField>
+      </EditorRow>
+    </EditorRows>
   );
 }

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { QueryEditorProps } from '@grafana/data';
+import { EditorRow } from '@grafana/experimental';
 import { DataSource } from '../DataSource';
 import { LogScaleOptions, LogScaleQuery } from '../types';
 import { LogScaleQueryEditor } from 'components/LogScaleQueryEditor';
-import { InlineSwitch } from '@grafana/ui';
+import { Field, Switch } from '@grafana/ui';
 
 export type Props = QueryEditorProps<DataSource, LogScaleQuery, LogScaleOptions>;
 
@@ -30,14 +31,15 @@ export function QueryEditor(props: Props) {
     <div>
       <LogScaleQueryEditor {...props} />
       {props.app === 'explore' ? (
-        <InlineSwitch
-          aria-label="formatLogs"
-          label="Format as logs"
-          showLabel={true}
-          value={isLogFormat || false}
-          onChange={(e) => onIsExploreChange(e.currentTarget.checked)}
-          transparent={true}
-        />
+        <EditorRow>
+          <Field label="Format as logs">
+            <Switch
+              id="formatLogs"
+              value={isLogFormat || false}
+              onChange={(e) => onIsExploreChange(e.currentTarget.checked)}
+            />
+          </Field>
+        </EditorRow>
       ) : (
         ''
       )}


### PR DESCRIPTION
Update the query editor to use components from `@grafana/experimental` or `@grafana/ui`. This removes some of the effort of adding class names to components ourselves and improves consistency.

![image](https://github.com/grafana/falconlogscale-datasource/assets/15019026/14cf1753-2e01-409f-9454-6884fce992ed)

A part of grafana/grafana#66479 and grafana/oss-plugin-partnerships#225

Fixes grafana/oss-plugin-partnerships#270