### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.0
+
+- Minimum Grafana required version is now **9.5.0**
+- Logs in explore view can be filtered for a value or filtered out by a value.
+- The settings UI has been overhauled to use the new Grafana form and authentication components.
+
 ## 1.0.1
 
 - Bug: TLS option are now correctly passed to the LogScale client.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.1.0
 
 - Minimum Grafana required version is now **9.5.0**
-- Logs in explore view can be filtered for a value or filtered out by a value.
+- Logs in explore view can be filtered by a value or filtered out by a value.
 - The settings UI has been overhauled to use the new Grafana form and authentication components.
 
 ## 1.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-falconlogscale-datasource",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Falcon LogScale data source plugin for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
- Minimum Grafana required version is now **9.5.0**
- Logs in explore view can be filtered by a value or filtered out by a value.
- The settings UI has been overhauled to use the new Grafana form and authentication components.