### PR TITLE
Fix load repositories button

### DIFF
--- a/src/components/ConfigEditor.test.tsx
+++ b/src/components/ConfigEditor.test.tsx
@@ -7,13 +7,13 @@ import { selectors } from 'e2e/selectors';
 const getDefaultProps = (): Props => {
   const options: Partial<Props['options']> = {
     jsonData: {
-      baseUrl: 'https://test-default.com',
       authenticateWithToken: false,
     },
     secureJsonData: {},
     secureJsonFields: {
       basicAuthPassword: false,
     },
+    url: 'https://test-default.com',
   };
 
   return {
@@ -33,7 +33,7 @@ describe('<ConfigEditor />', () => {
 
   it('should render URL when it is passed', () => {
     const props = getDefaultProps();
-    props.options.url = props.options.jsonData.baseUrl = 'http://humio-test.test';
+    props.options.url = 'http://humio-test.test';
 
     render(<ConfigEditor {...props} />);
 
@@ -59,6 +59,7 @@ describe('<ConfigEditor />', () => {
     await userEvent.tab();
 
     expect(props.onOptionsChange).toHaveBeenCalledWith({
+      ...props.options,
       jsonData: {
         ...props.options.jsonData,
         authenticateWithToken: true,
@@ -81,6 +82,7 @@ describe('<ConfigEditor />', () => {
     await userEvent.click(screen.getByText('Reset'));
 
     expect(props.onOptionsChange).toHaveBeenCalledWith({
+      ...props.options,
       jsonData: {
         ...props.options.jsonData,
         authenticateWithToken: false,

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -75,7 +75,10 @@ export const ConfigEditor: React.FC<Props> = (props: Props) => {
 
   useEffect(() => {
     setDisabled(true);
-    if (options.jsonData.baseUrl && (options.secureJsonFields?.accessToken || options.secureJsonData?.accessToken)) {
+    if (
+      (options.jsonData.baseUrl || options.url) &&
+      (options.secureJsonFields?.accessToken || options.secureJsonData?.accessToken)
+    ) {
       setDisabled(false);
     }
   }, [options]);


### PR DESCRIPTION
Fixes a bug that wouldn't enable the load repositories button when the URL and token have been inputted