### PR TITLE
Add a function to prepend `@timestamp` field

### DIFF
--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -152,6 +152,18 @@ func TestOrderFrameFieldsByMetaData(t *testing.T) {
 	})
 }
 
+func TestPrependTimestampField(t *testing.T) {
+	t.Run("places timestamp field at beginning of frame", func(t *testing.T) {
+		frame := data.NewFrame("test",
+			data.NewField("c", nil, []string{"d", "e", "f"}),
+			data.NewField("a", nil, []string{"g", "h", "i"}),
+			data.NewField("@timestamp", nil, []string{"a", "b", "c"}),
+		)
+		plugin.PrependTimestampField(frame)
+		experimental.CheckGoldenJSONFrame(t, "../test_data", "prepend_timestamp_field", frame, true)
+	})
+}
+
 func TestConvertToWideFormat(t *testing.T) {
 	t.Run("wide format with no fields", func(t *testing.T) {
 		frame := data.NewFrame("test")

--- a/pkg/test_data/prepend_timestamp_field.jsonc
+++ b/pkg/test_data/prepend_timestamp_field.jsonc
@@ -1,0 +1,69 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] 
+//  Name: test
+//  Dimensions: 3 Fields by 3 Rows
+//  +------------------+----------------+----------------+
+//  | Name: @timestamp | Name: c        | Name: a        |
+//  | Labels:          | Labels:        | Labels:        |
+//  | Type: []string   | Type: []string | Type: []string |
+//  +------------------+----------------+----------------+
+//  | a                | d              | g              |
+//  | b                | e              | h              |
+//  | c                | f              | i              |
+//  +------------------+----------------+----------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "test",
+        "fields": [
+          {
+            "name": "@timestamp",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "c",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "a",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "a",
+            "b",
+            "c"
+          ],
+          [
+            "d",
+            "e",
+            "f"
+          ],
+          [
+            "g",
+            "h",
+            "i"
+          ]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The logs visualisation uses the first field of type `time` as the timestamp value displayed. This presents a problem in LogScale as the `@ingesttimestamp` (ingestion time in LogScale) field often is higher order than the `@timestamp` (log timestamp) field.

This change adds a function that will always move the `@timestamp` field to the beginning of the fields slice in the data-frame, ensuring that it is always used as the timestamp displayed in the visualisation.

Fixes grafana/support-escalations#9287