### PR TITLE
Remove @grafana/experimental ignore from dependency group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
     groups:
       dependencies:
         patterns:
-          - "!(@grafana/experimental)@grafana/*"
+          - "@grafana/*"
       dev-dependencies:
         patterns:
           - "@grafana/e2e*"


### PR DESCRIPTION
Looks like the glob pattern to ignore `@grafana/experimental` didn't work... 👎 