### PR TITLE
Fix `VariableEditor` update depth error

### DIFF
--- a/src/components/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor.tsx
@@ -1,29 +1,23 @@
 import { DataSource } from 'DataSource';
-import React, { useState } from 'react';
+import React from 'react';
 import { LogScaleQuery } from 'types';
 import { LogScaleQueryEditor } from 'components/LogScaleQueryEditor';
 
 export type Props = {
   query: LogScaleQuery;
-  onChange: (q: LogScaleQuery, desc: string) => void;
+  onChange: (q: LogScaleQuery) => void;
   datasource: DataSource;
 };
 
 export function VariableQueryEditor(props: Props) {
-  const { onChange, datasource } = props;
-  const [query, setQuery] = useState(props.query || ({} as LogScaleQuery));
-
-  const handleVariableQuery = (q: LogScaleQuery) => {
-    setQuery(q);
-    onChange(q, `LogScale Query - ${query.lsql}`);
-  };
+  const { onChange, datasource, query } = props;
 
   return (
     <LogScaleQueryEditor
       datasource={datasource}
-      onChange={handleVariableQuery}
-      onRunQuery={() => handleVariableQuery(query)}
-      query={query}
+      onChange={onChange}
+      onRunQuery={() => onChange(query)}
+      query={query ?? {}}
     />
   );
 }


### PR DESCRIPTION
Excess logic in the variable editor was causing an infinite loop leading to a React max update depth error. The fix here is to remove the inner state `query` variable as it's unneeded and accessible from the props anyway.

Fixes grafana/support-escalations#9723