### PR TITLE
Add errorsource

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -31,6 +31,7 @@
     "falconlogscale",
     "framestruct",
     "grafana",
+    "errorsource",
     "httpadapter",
     "httpclient",
     "humio",

--- a/pkg/humio/client.go
+++ b/pkg/humio/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"github.com/hasura/go-graphql-client"
 )
 
@@ -46,7 +47,9 @@ func (c *Client) CreateJob(repo string, query Query) (string, error) {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(humioQuery)
 	if err != nil {
-		return "", err
+		// This is technically a plugin error so we set it here
+		// to avoid it being overwritten by a higher level errorsource call
+		return "", errorsource.PluginError(err, false)
 	}
 
 	err = c.Fetch(http.MethodPost, "api/v1/repositories/"+url.QueryEscape(repo)+"/queryjobs", &buf, &jsonResponse)
@@ -91,7 +94,12 @@ func (c *Client) ListRepos() ([]string, error) {
 	for _, v := range query.Views {
 		f = append(f, v.Name)
 	}
-	return f, err
+
+	if err != nil {
+		return f, errorsource.DownstreamError(err, false)
+	}
+
+	return f, nil
 }
 
 func (c *Client) setAuthHeaders() graphql.RequestModifier {
@@ -109,7 +117,7 @@ func (c *Client) newGraphQLClient() (*graphql.Client, error) {
 func (c *Client) GraphQLQuery(query interface{}, variables map[string]interface{}) error {
 	client, err := c.newGraphQLClient()
 	if err != nil {
-		return err
+		return errorsource.PluginError(err, false)
 	}
 	return client.Query(context.Background(), query, variables)
 }

--- a/pkg/humio/runner.go
+++ b/pkg/humio/runner.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 )
 
 type JobQuerier interface {
@@ -77,7 +78,7 @@ func (qj *QueryRunner) Run(query Query) ([]QueryResult, error) {
 	}()
 
 	if err != nil {
-		return nil, err
+		return nil, errorsource.DownstreamError(err, false)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Add `errorsource` to any errors that are downstream and may be returned at some point in the `QueryData` endpoint. A downstream error is anything that is not due to the plugin directly.
