### PR TITLE
chore: update readme link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The CrowdStrike Falcon LogScale data source plugin allows you to query and visua
 
 [Technical documentation](https://grafana.com/docs/plugins/grafana-falconlogscale-datasource/latest/)
 
-[License](https://github.com/grafana/falconlogscale-datasource/blob/mooose-update-docs-link/LICENSE))
+[License](https://github.com/grafana/falconlogscale-datasource/blob/mooose-update-docs-link/LICENSE)

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The CrowdStrike Falcon LogScale data source plugin allows you to query and visua
 
 [Technical documentation](https://grafana.com/docs/plugins/grafana-falconlogscale-datasource/latest/)
 
-[License](LICENSE)
+[License](https://github.com/grafana/falconlogscale-datasource/blob/mooose-update-docs-link/LICENSE))

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The CrowdStrike Falcon LogScale data source plugin allows you to query and visua
 
 [Technical documentation](https://grafana.com/docs/plugins/grafana-falconlogscale-datasource/latest/)
 
-[License](https://github.com/grafana/falconlogscale-datasource/blob/mooose-update-docs-link/LICENSE)
+[License](https://github.com/grafana/falconlogscale-datasource/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ The CrowdStrike Falcon LogScale data source plugin allows you to query and visua
 
 ## See also
 
-[Technical documentation](https://grafana.com/docs/plugins/grafana-azurecosmosdb-datasource/latest/)
+[Technical documentation](https://grafana.com/docs/plugins/grafana-falconlogscale-datasource/latest/)
 
 [License](LICENSE)


### PR DESCRIPTION
Docs were linking to incorrect DS

License link needed to be absolute to work on grafana.com etc