### PR TITLE
Template variable queries return fields as strings

### DIFF
--- a/pkg/humio/models.go
+++ b/pkg/humio/models.go
@@ -20,8 +20,9 @@ const (
 )
 
 const (
-	FormatMetrics = "metrics"
-	FormatLogs    = "logs"
+	FormatMetrics  = "metrics"
+	FormatLogs     = "logs"
+	FormatVariable = "variable"
 )
 
 type QueryResult struct {

--- a/pkg/plugin/handler.go
+++ b/pkg/plugin/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data/framestruct"
 )
 
+type FrameMarshallerFunc func(string, interface{}, ...framestruct.FramestructOption) (*data.Frame, error)
 type humioClient interface {
 }
 
@@ -25,7 +26,7 @@ type Handler struct {
 	Client          humioClient
 	QueryRunner     queryRunner
 	ResourceHandler backend.CallResourceHandler
-	FrameMarshaller func(string, interface{}, ...framestruct.FramestructOption) (*data.Frame, error)
+	FrameMarshaller FrameMarshallerFunc
 	Settings        Settings
 
 	// open streams

--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -206,6 +206,17 @@ func TestValidateQuery(t *testing.T) {
 	})
 }
 
+func TestFormatAsVariableQuery(t *testing.T) {
+	t.Run("query uses default frame converters when formatAs is set to variable", func(t *testing.T) {
+		events := []map[string]any{
+			{"_count": "100", "stringField": "hello", "@timestamp": "2020-01-01T00:00:00Z"},
+			{"stringField": "hello", "extraField": "extra"},
+		}
+		err := plugin.BuildDataFrame(humio.FormatVariable, fakeFrameMarshaller, events)
+		require.NoError(t, err)
+	})
+}
+
 func newFakeFalconClient() *fakeFalconClient {
 	return &fakeFalconClient{}
 }

--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -206,13 +206,29 @@ func TestValidateQuery(t *testing.T) {
 	})
 }
 
-func TestFormatAsVariableQuery(t *testing.T) {
+func TestFormatQuery(t *testing.T) {
 	t.Run("query uses default frame converters when formatAs is set to variable", func(t *testing.T) {
 		events := []map[string]any{
-			{"_count": "100", "stringField": "hello", "@timestamp": "2020-01-01T00:00:00Z"},
-			{"stringField": "hello", "extraField": "extra"},
+			{"numberField": "100", "@timestamp": "2020-01-01T00:00:00Z"},
+			{"numberField": "101", "@timestamp": "2020-01-01T00:01:00Z"},
 		}
-		err := plugin.BuildDataFrame(humio.FormatVariable, fakeFrameMarshaller, events)
+
+		queryResult := humio.QueryResult{Events: events}
+		frame, err := plugin.BuildDataFrame(humio.FormatVariable, framestruct.ToDataFrame, queryResult)
+		//in the frame, numberField should be a string and @timestamp should be string
+		experimental.CheckGoldenJSONFrame(t, "../test_data", "formatAs_set_to_variable", frame, false)
+		require.NoError(t, err)
+	})
+	t.Run("query uses custom frame converters when formatAs is set to metrics", func(t *testing.T) {
+		events := []map[string]any{
+			{"numberField": "100", "@timestamp": "2020-01-01T00:00:00Z"},
+			{"numberField": "101", "@timestamp": "2020-01-01T00:01:00Z"},
+		}
+
+		queryResult := humio.QueryResult{Events: events}
+		frame, err := plugin.BuildDataFrame(humio.FormatMetrics, framestruct.ToDataFrame, queryResult)
+		//in the frame, numberField should be a number and @timestamp should be time
+		experimental.CheckGoldenJSONFrame(t, "../test_data", "formatAs_set_to_metric", frame, false)
 		require.NoError(t, err)
 	})
 }

--- a/pkg/test_data/formatAs_set_to_metric.jsonc
+++ b/pkg/test_data/formatAs_set_to_metric.jsonc
@@ -1,0 +1,56 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] 
+//  Name: events
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+-------------------+
+//  | Name: @timestamp              | Name: numberField |
+//  | Labels:                       | Labels:           |
+//  | Type: []*time.Time            | Type: []*float64  |
+//  +-------------------------------+-------------------+
+//  | 2020-01-01 00:00:00 +0000 UTC | 100               |
+//  | 2020-01-01 00:01:00 +0000 UTC | 101               |
+//  +-------------------------------+-------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "events",
+        "fields": [
+          {
+            "name": "@timestamp",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time",
+              "nullable": true
+            }
+          },
+          {
+            "name": "numberField",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1577836800000,
+            1577836860000
+          ],
+          [
+            100,
+            101
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/test_data/formatAs_set_to_variable.jsonc
+++ b/pkg/test_data/formatAs_set_to_variable.jsonc
@@ -1,0 +1,56 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] 
+//  Name: events
+//  Dimensions: 2 Fields by 2 Rows
+//  +----------------------+-------------------+
+//  | Name: @timestamp     | Name: numberField |
+//  | Labels:              | Labels:           |
+//  | Type: []*string      | Type: []*string   |
+//  +----------------------+-------------------+
+//  | 2020-01-01T00:00:00Z | 100               |
+//  | 2020-01-01T00:01:00Z | 101               |
+//  +----------------------+-------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "events",
+        "fields": [
+          {
+            "name": "@timestamp",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "numberField",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string",
+              "nullable": true
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "2020-01-01T00:00:00Z",
+            "2020-01-01T00:01:00Z"
+          ],
+          [
+            "100",
+            "101"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/components/VariableEditor/VariableQueryEditor.test.tsx
+++ b/src/components/VariableEditor/VariableQueryEditor.test.tsx
@@ -38,7 +38,7 @@ describe('<VariableQueryEditor />', () => {
     expect(props.onChange).toHaveBeenCalledWith(
       expect.objectContaining({
         lsql: 'test-lql-query',
-        formatAs: FormatAs.Logs,
+        formatAs: FormatAs.Variable,
         queryType: LogScaleQueryType.LQL,
         repository: 'test-repository',
       })

--- a/src/components/VariableEditor/VariableQueryEditor.tsx
+++ b/src/components/VariableEditor/VariableQueryEditor.tsx
@@ -28,7 +28,7 @@ const VariableQueryEditor = (props: Props) => {
       onChange({
         refId: 'A',
         repository: datasource.defaultRepository ?? '',
-        formatAs: FormatAs.Logs,
+        formatAs: FormatAs.Variable,
         lsql: query,
         queryType: LogScaleQueryType.LQL,
         version

--- a/src/dataLink.ts
+++ b/src/dataLink.ts
@@ -29,7 +29,7 @@ export function getDataLinks(dataFrame: DataFrame, dataLinkConfigs: DataLinkConf
   return dataLinks.map((f) => f.newField);
 }
 
-function dataLinkConfigToDataFrameField(dataLinkConfig: DataLinkConfig): Field<any, Array<string | null>> {
+function dataLinkConfigToDataFrameField(dataLinkConfig: DataLinkConfig): Field<any> {
   const dataSourceSrv = getDataSourceSrv();
 
   let dataLink = {} as DataLink;

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -1,7 +1,7 @@
 import { DataFrame, DataQueryRequest, DataQueryResponse, Field, isDataFrame } from '@grafana/data';
 import { getDataLinks } from 'dataLink';
 import { DataLinkConfig } from './components/DataLinks';
-import { LogScaleQuery } from 'types';
+import { FormatAs, LogScaleQuery } from 'types';
 
 export function transformBackendResult(
   response: DataQueryResponse,
@@ -30,7 +30,7 @@ function processFrames(
 ): DataFrame[] {
   return frames.map((frame) => {
     const targetQuery = request.targets.find((x) => x.refId === frame.refId);
-    if (!targetQuery || targetQuery.formatAs !== 'logs') {
+    if (!targetQuery || targetQuery.formatAs !== FormatAs.Logs) {
       return {
         ...frame,
         fields: [...orderFields(frame.fields)],
@@ -43,7 +43,7 @@ function processFrames(
   });
 }
 
-function orderFields(fields: Array<Field<any, any[]>>): Array<Field<any, any[]>> {
+function orderFields(fields: Array<Field<any>>): Array<Field<any>> {
   const rawstringFieldIndex = fields.findIndex((x) => x.name === '@rawstring');
   if (rawstringFieldIndex === -1) {
     return fields;

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,4 +34,5 @@ export enum LogScaleQueryType {
 export enum FormatAs {
   Logs = 'logs',
   Metrics = 'metrics',
+  Variable = 'variable',
 }


### PR DESCRIPTION
Before template var queries returned normally, so number fields could not be used. This change makes template var queries return all fields as strings. 

Also refactored query.go to make it easier to unit test framing.