### PR TITLE
correct X-Id-Token when fetching repos 

### DIFF
--- a/pkg/humio/client.go
+++ b/pkg/humio/client.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
@@ -163,13 +164,13 @@ type ErrorResponse struct {
 }
 
 func (c *Client) addAuthHeaders(req *http.Request) *http.Request {
-	authHeader := c.Auth.AuthHeaders["Authorization"]
-	idTokenHeader := c.Auth.AuthHeaders["X-Id-Token"]
+	authHeader := c.Auth.AuthHeaders[backend.OAuthIdentityTokenHeaderName]
+	idTokenHeader := c.Auth.AuthHeaders[backend.OAuthIdentityIDTokenHeaderName]
 	if c.OAuthPassThru && authHeader != "" && idTokenHeader != "" {
-		req.Header.Set("Authorization", authHeader)
-		req.Header.Set("X-Id-Token", idTokenHeader)
+		req.Header.Set(backend.OAuthIdentityTokenHeaderName, authHeader)
+		req.Header.Set(backend.OAuthIdentityIDTokenHeaderName, idTokenHeader)
 	} else {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.AccessToken))
+		req.Header.Set(backend.OAuthIdentityTokenHeaderName, fmt.Sprintf("Bearer %s", c.AccessToken))
 	}
 
 	return req

--- a/pkg/humio/client_test.go
+++ b/pkg/humio/client_test.go
@@ -84,7 +84,7 @@ func TestClient(t *testing.T) {
 		defer teardownClientTest()
 		testMux.HandleFunc("/graphql", func(w http.ResponseWriter, req *http.Request) {
 			tokenHeader := "Bearer testToken"
-			reqTokenHeader := req.Header.Get("Authorization")
+			reqTokenHeader := req.Header.Get(backend.OAuthIdentityTokenHeaderName)
 			require.Equal(t, tokenHeader, reqTokenHeader)
 			fmt.Fprint(w, "{}")
 		})

--- a/pkg/humio/client_test.go
+++ b/pkg/humio/client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/grafana/falconlogscale-datasource-backend/pkg/humio"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/plugin/callresource.go
+++ b/pkg/plugin/callresource.go
@@ -29,19 +29,19 @@ func handleRepositories(c *humio.Client, repositories func() ([]string, error)) 
 	return func(w http.ResponseWriter, req *http.Request) {
 		authorizationHeader := ""
 		idTokenHeader := ""
-		if len(req.Header["Authorization"]) > 0 {
-			authorizationHeader = req.Header["Authorization"][0]
+		if len(req.Header[backend.OAuthIdentityTokenHeaderName]) > 0 {
+			authorizationHeader = req.Header[backend.OAuthIdentityTokenHeaderName][0]
 		}
 
 		// We don't lint the next line as the headers are expected to be canonical but this is not the case
 		//nolint:all
-		if len(req.Header["X-Id-Token"]) > 0 {
-			idTokenHeader = req.Header["X-Id-Token"][0]
+		if len(req.Header[backend.OAuthIdentityIDTokenHeaderName]) > 0 {
+			idTokenHeader = req.Header[backend.OAuthIdentityIDTokenHeaderName][0]
 		}
 
 		authHeaders := map[string]string{
-			"Authorization": authorizationHeader,
-			"X-Id-Token":    idTokenHeader,
+			backend.OAuthIdentityTokenHeaderName: authorizationHeader,
+			backend.OAuthIdentityIDTokenHeaderName:    idTokenHeader,
 		}
 		c.SetAuthHeaders(authHeaders)
 		resp, err := repositories()

--- a/pkg/plugin/callresource.go
+++ b/pkg/plugin/callresource.go
@@ -35,8 +35,8 @@ func handleRepositories(c *humio.Client, repositories func() ([]string, error)) 
 
 		// We don't lint the next line as the headers are expected to be canonical but this is not the case
 		//nolint:all
-		if len(req.Header["X-ID-Token"]) > 0 {
-			idTokenHeader = req.Header["X-ID-Token"][0]
+		if len(req.Header["X-Id-Token"]) > 0 {
+			idTokenHeader = req.Header["X-Id-Token"][0]
 		}
 
 		authHeaders := map[string]string{

--- a/pkg/plugin/callresource.go
+++ b/pkg/plugin/callresource.go
@@ -27,19 +27,9 @@ func ResourceHandler(c *humio.Client) http.Handler {
 
 func handleRepositories(c *humio.Client, repositories func() ([]string, error)) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		authorizationHeader := ""
-		idTokenHeader := ""
-		if len(req.Header[backend.OAuthIdentityTokenHeaderName]) > 0 {
-			authorizationHeader = req.Header[backend.OAuthIdentityTokenHeaderName][0]
-		}
-
-		if len(req.Header[backend.OAuthIdentityIDTokenHeaderName]) > 0 {
-			idTokenHeader = req.Header[backend.OAuthIdentityIDTokenHeaderName][0]
-		}
-
 		authHeaders := map[string]string{
-			backend.OAuthIdentityTokenHeaderName:   authorizationHeader,
-			backend.OAuthIdentityIDTokenHeaderName: idTokenHeader,
+			backend.OAuthIdentityTokenHeaderName:   req.Header.Get(backend.OAuthIdentityTokenHeaderName),
+			backend.OAuthIdentityIDTokenHeaderName: req.Header.Get(backend.OAuthIdentityIDTokenHeaderName),
 		}
 		c.SetAuthHeaders(authHeaders)
 		resp, err := repositories()

--- a/pkg/plugin/healthcheck.go
+++ b/pkg/plugin/healthcheck.go
@@ -8,8 +8,8 @@ import (
 
 func (h *Handler) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	authHeaders := map[string]string{
-		"Authorization": req.GetHTTPHeader("Authorization"),
-		"X-Id-Token":    req.GetHTTPHeader("X-Id-Token"),
+		backend.OAuthIdentityTokenHeaderName: req.GetHTTPHeader(backend.OAuthIdentityTokenHeaderName),
+		backend.OAuthIdentityIDTokenHeaderName:    req.GetHTTPHeader(backend.OAuthIdentityIDTokenHeaderName),
 	}
 	h.QueryRunner.SetAuthHeaders(authHeaders)
 	// Check if we can view our humio repos

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -30,8 +30,8 @@ func (h *Handler) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		}
 
 		authHeaders := map[string]string{
-			"Authorization": req.GetHTTPHeader("Authorization"),
-			"X-Id-Token":    req.GetHTTPHeader("X-Id-Token"),
+			backend.OAuthIdentityTokenHeaderName: req.GetHTTPHeader(backend.OAuthIdentityTokenHeaderName),
+			backend.OAuthIdentityIDTokenHeaderName:    req.GetHTTPHeader(backend.OAuthIdentityIDTokenHeaderName),
 		}
 		h.QueryRunner.SetAuthHeaders(authHeaders)
 

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -30,8 +30,8 @@ func (h *Handler) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		}
 
 		authHeaders := map[string]string{
-			backend.OAuthIdentityTokenHeaderName: req.GetHTTPHeader(backend.OAuthIdentityTokenHeaderName),
-			backend.OAuthIdentityIDTokenHeaderName:    req.GetHTTPHeader(backend.OAuthIdentityIDTokenHeaderName),
+			backend.OAuthIdentityTokenHeaderName:   req.GetHTTPHeader(backend.OAuthIdentityTokenHeaderName),
+			backend.OAuthIdentityIDTokenHeaderName: req.GetHTTPHeader(backend.OAuthIdentityIDTokenHeaderName),
 		}
 		h.QueryRunner.SetAuthHeaders(authHeaders)
 


### PR DESCRIPTION
in https://github.com/grafana/grafana/pull/90892, token header has changed from` X-ID-Token` to `X-Id-Token`

This header is case sensitive. Therefore,  capital "D" prevents fetching repos when using  OAuthPass. 
This also breaks datasource creation because we set an [empty X-Id-Token](https://github.com/grafana/falconlogscale-datasource/blob/3c73582c1ad652fc6e4ce7062db35892d1dea093/pkg/plugin/callresource.go#L42-L46) while handling repos,  which in turn disables [oauth pass through entirely ](https://github.com/grafana/falconlogscale-datasource/blob/3c73582c1ad652fc6e4ce7062db35892d1dea093/pkg/humio/client.go#L168-L173)