### PR TITLE
Correctly set logs format by default in explore

### DIFF
--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -16,7 +16,7 @@ export function QueryEditor(props: Props) {
   // This sets the query type to logs if the user is in Explore and the query type is not set
   useEffect(() => {
     if (props.app === 'explore' && !query.queryType) {
-      onChange({ ...query, queryType: LogScaleQueryType.LQL });
+      onChange({ ...query, queryType: LogScaleQueryType.LQL, formatAs: FormatAs.Logs });
       setIsLogFormat(true);
       onRunQuery();
     }


### PR DESCRIPTION
Previously explore would set the flag for `Format As Logs` but it wouldn't format as logs without toggling the flag. Now `formatAs` is correctly assigned