### PR TITLE
Set user error in LoadSettings to downstream

### DIFF
--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -28,13 +28,13 @@ var (
 func LoadSettings(config backend.DataSourceInstanceSettings) (Settings, error) {
 	settings := Settings{}
 	if err := json.Unmarshal(config.JSONData, &settings); err != nil {
-		return settings, fmt.Errorf("could not unmarshal DataSourceInfo json: %w", err)
+		return settings, backend.DownstreamError(fmt.Errorf("could not unmarshal DataSourceInfo json: %w", err))
 	}
 
 	baseURL := config.URL
 	settings.BaseURL = baseURL
 	if baseURL == "" {
-		return Settings{}, errEmptyURL
+		return Settings{}, backend.DownstreamError(errEmptyURL)
 	}
 
 	if settings.AuthenticateWithToken {

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -1,0 +1,56 @@
+package plugin
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadSettings(t *testing.T) {
+	t.Run("should return error when URL is empty", func(t *testing.T) {
+		config := backend.DataSourceInstanceSettings{
+			URL:      "",
+			JSONData: []byte(`{}`),
+		}
+
+		_, err := LoadSettings(config)
+		require.Error(t, err)
+		require.ErrorIs(t, err, backend.DownstreamError(errEmptyURL))
+	})
+
+	t.Run("should not return error when URL is not empty", func(t *testing.T) {
+		config := backend.DataSourceInstanceSettings{
+			URL:      "http://localhost:8080",
+			JSONData: []byte(`{}`),
+		}
+
+		_, err := LoadSettings(config)
+		require.NoError(t, err)
+	})
+
+	t.Run("should return error when JSONData cannot be unmarshaled", func(t *testing.T) {
+		config := backend.DataSourceInstanceSettings{
+			URL:      "http://localhost:8080",
+			JSONData: []byte(`{invalid json}`),
+		}
+
+		_, err := LoadSettings(config)
+		require.Error(t, err)
+		require.ErrorIs(t, err, backend.DownstreamError(fmt.Errorf("could not unmarshal DataSourceInfo json: %w", err)))
+	})
+
+	t.Run("should load settings successfully with valid config", func(t *testing.T) {
+		config := backend.DataSourceInstanceSettings{
+			URL:      "http://localhost:8080",
+			JSONData: []byte(`{"authenticateWithToken": true}`),
+		}
+
+		settings, err := LoadSettings(config)
+		require.NoError(t, err)
+		require.Equal(t, "http://localhost:8080", settings.BaseURL)
+		require.Equal(t, "http://localhost:8080/humio/graphql", settings.GraphqlEndpoint)
+		require.Equal(t, "http://localhost:8080/humio", settings.RestEndpoint)
+	})
+}

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -30,7 +30,7 @@ func TestLoadSettings(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("should return error when JSONData cannot be unmarshaled", func(t *testing.T) {
+	t.Run("should return error when invalid JSONData provided", func(t *testing.T) {
 		config := backend.DataSourceInstanceSettings{
 			URL:      "http://localhost:8080",
 			JSONData: []byte(`{invalid json}`),


### PR DESCRIPTION
This PR sets error source for errEmptyURL and invalid settings to downstream. The error was noticed in https://ops.grafana-ops.net/goto/kmSLaE5Ng?orgId=1

<img width="966" alt="image" src="https://github.com/user-attachments/assets/4af0f4ba-3e2f-4c67-8dd6-f32c00946486" />
