### PR TITLE
GHA: Harden workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
       archive: ${{ steps.metadata.outputs.archive }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4.1.0
@@ -62,13 +64,13 @@ jobs:
           go-version-file: go.mod
 
       - name: Test backend
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b
         with:
           version: latest
           args: coverage
 
       - name: Build backend
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b
         with:
           version: latest
           args: buildAll
@@ -88,9 +90,12 @@ jobs:
 
       - name: Package plugin
         id: package-plugin
+        env:
+          PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
+          PLUGIN_ARCHIVE: ${{ steps.metadata.outputs.archive }}
         run: |
-          mv dist ${{ steps.metadata.outputs.plugin-id }}
-          zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
+          mv dist ${PLUGIN_ID}
+          zip ${PLUGIN_ARCHIVE} ${PLUGIN_ID} -r
 
       - name: Archive Build
         uses: actions/upload-artifact@v4
@@ -124,6 +129,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -144,9 +151,12 @@ jobs:
           name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
 
       - name: Unpack build
+        env:
+          PLUGIN_ID: ${{ needs.build.outputs.plugin-id }}
+          PLUGIN_ARCHIVE: ${{ needs.build.outputs.archive }}
         run: |
-          unzip ${{ needs.build.outputs.archive }}
-          mv ${{ needs.build.outputs.plugin-id }} dist
+          unzip ${PLUGIN_ARCHIVE}
+          mv ${PLUGIN_ID} dist
 
       - name: Start Grafana
         shell: bash
@@ -174,6 +184,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -194,9 +206,12 @@ jobs:
           name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
 
       - name: Unpack build
+        env:
+          PLUGIN_ID: ${{ needs.build.outputs.plugin-id }}
+          PLUGIN_ARCHIVE: ${{ needs.build.outputs.archive }}
         run: |
-          unzip ${{ needs.build.outputs.archive }}
-          mv ${{ needs.build.outputs.plugin-id }} dist
+          unzip ${PLUGIN_ARCHIVE}
+          mv ${PLUGIN_ID} dist
 
       - name: Start Grafana
         shell: bash

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -6,6 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-node@v4.1.0
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -12,6 +12,7 @@ jobs:
           repository: 'grafana/grafana-github-actions'
           path: ./actions
           ref: main
+          persist-credentials: false
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run Commands

--- a/.github/workflows/pull-request-image.yml
+++ b/.github/workflows/pull-request-image.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - main
 
-permissions:
-  pull-requests: write
-  issues: write
-
 jobs:
   build:
     name: Build and archive plugin build artifacts
@@ -19,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4.1.0
@@ -63,6 +61,11 @@ jobs:
 
       - name: Generate Dockerfile
         shell: bash
+        env:
+          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.number }}
         run: |
           echo "FROM grafana/grafana-oss:latest
 
@@ -76,21 +79,21 @@ jobs:
           ENV GF_DEFAULT_APP_MODE "development"
 
           # TODO: Cleanup script should remove images from closed PRs using these labels
-          LABEL gh-sha="${{ github.event.pull_request.head.sha }}"
-          LABEL gh-repo="${{ github.event.repository.name }}"
-          LABEL gh-pr-number="${{ github.event.number }}"
+          LABEL gh-sha="${PR_SHA}"
+          LABEL gh-repo="${GITHUB_REPOSITORY_NAME}"
+          LABEL gh-pr-number="${PR_NUMBER}"
 
           # Copy plugin build artifacts into the image
-          COPY . /var/lib/grafana/plugins/${{ github.event.repository.name }}/" > Dockerfile
+          COPY . /var/lib/grafana/plugins/${GITHUB_REPOSITORY_NAME}/" > Dockerfile
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1
         with:
           context: .
           file: ./Dockerfile
@@ -98,18 +101,21 @@ jobs:
           tags: grafana/plugin-builds:${{ github.event.pull_request.head.sha }}pre
   add_pr_comment:
     name: Add PR comment
+    permissions:
+      pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     needs: push_to_registry
     steps:
       - name: Find previous comment (if any)
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
         id: fc
         with:
           issue-number: ${{ github.event.number }}
           body-includes: Use the following command to run this PR with Docker
       - name: Update comment on PR
         if: steps.fc.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace
@@ -122,7 +128,7 @@ jobs:
               ```
       - name: Add comment to PR
         if: steps.fc.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           issue-number: ${{ github.event.number }}
           body: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4.1.0
@@ -63,14 +65,14 @@ jobs:
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b
         with:
           version: latest
           args: coverage
 
       - name: Build backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b
         with:
           version: latest
           args: buildAll
@@ -106,23 +108,32 @@ jobs:
           echo "::set-output name=path::release_notes.md"
 
       - name: Check package version
-        run: if [ "v${{ steps.metadata.outputs.plugin-version }}" != "${{ steps.metadata.outputs.github-tag }}" ]; then printf "\033[0;31mPlugin version doesn't match tag name\033[0m\n"; exit 1; fi
+        env:
+          PLUGIN_VERSION: ${{ steps.metadata.outputs.plugin-version }}
+          GH_TAG: ${{ steps.metadata.outputs.github-tag }}
+        run: if [ "v${PLUGIN_VERSION}" != "${GH_TAG}" ]; then printf "\033[0;31mPlugin version doesn't match tag name\033[0m\n"; exit 1; fi
 
       - name: Package plugin
         id: package-plugin
+        env:
+          PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
+          ARCHIVE: ${{ steps.metadata.outputs.archive }}
+          ARCHIVE_CHECKSUM: ${{ steps.metadata.outputs.archive-checksum }}
         run: |
-          mv dist ${{ steps.metadata.outputs.plugin-id }}
-          zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
-          md5sum ${{ steps.metadata.outputs.archive }} > ${{ steps.metadata.outputs.archive-checksum }}
-          echo "::set-output name=checksum::$(cat ./${{ steps.metadata.outputs.archive-checksum }} | cut -d' ' -f1)"
+          mv dist ${PLUGIN_ID}
+          zip ${ARCHIVE} ${PLUGIN_ID} -r
+          md5sum ${ARCHIVE} > ${ARCHIVE_CHECKSUM}
+          echo "::set-output name=checksum::$(cat ./${ARCHIVE_CHECKSUM} | cut -d' ' -f1)"
 
       - name: Lint plugin
+        env:
+          ARCHIVE: ${{ steps.metadata.outputs.archive }}
         run: |
           git clone https://github.com/grafana/plugin-validator
           pushd ./plugin-validator/pkg/cmd/plugincheck
           go install
           popd
-          plugincheck ${{ steps.metadata.outputs.archive }}
+          plugincheck ${ARCHIVE}
 
       - name: Create release
         id: create_release
@@ -158,7 +169,15 @@ jobs:
           asset_content_type: text/plain
 
       - name: Publish to Grafana.com
+        env:
+          PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
+          PLUGIN_TYPE: ${{ steps.metadata.outputs.plugin-type }}
+          PLUGIN_VERSION: ${{ steps.metadata.outputs.plugin-version }}
+          ARCHIVE: ${{ steps.metadata.outputs.archive }}
+          CHECKSUM: ${{ steps.package-plugin.outputs.checksum }}
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
         run: |
           echo A draft release has been created for your plugin. Please review and publish it. Then submit your plugin to grafana.com/plugins by opening a PR to https://github.com/grafana/grafana-plugin-repository with the following entry:
           echo
-          echo '{ "id": "${{ steps.metadata.outputs.plugin-id }}", "type": "${{ steps.metadata.outputs.plugin-type }}", "url": "https://github.com/${{ github.repository }}", "versions": [ { "version": "${{ steps.metadata.outputs.plugin-version }}", "commit": "${{ github.sha }}", "url": "https://github.com/${{ github.repository }}", "download": { "any": { "url": "https://github.com/${{ github.repository }}/releases/download/v${{ steps.metadata.outputs.plugin-version }}/${{ steps.metadata.outputs.archive }}", "md5": "${{ steps.package-plugin.outputs.checksum }}" } } } ] }' | jq .
+          echo '{ "id": "${PLUGIN_ID}", "type": "${PLUGIN_TYPE}", "url": "https://github.com/${REPOSITORY}", "versions": [ { "version": "${PLUGIN_VERSION}", "commit": "${SHA}", "url": "https://github.com/${REPOSITORY}", "download": { "any": { "url": "https://github.com/${REPOSITORY}/releases/download/v${PLUGIN_VERSION}/${ARCHIVE}", "md5": "${CHECKSUM}" } } } ] }' | jq .


### PR DESCRIPTION
Fixing a bunch of issues reported by `zizmor`.

- Fix template injection issues.
- Pin third-party GitHub actions to specific SHAs. Excluding GitHub owned actions.
- Appropriately set permissions in workflows.
- Improve safety of checkout action.