### PR TITLE
Remove @types/testing-library__jest-dom, add CI GHA

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,23 @@
+name: Plugins - CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  ci:
+    name: CI
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      go-version: '1.24'
+      golangci-lint-version: '2.1.6'
+      run-playwright: false
+

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -42,6 +42,7 @@
     "Millis",
     "nanos",
     "nolint",
+    "errcheck",
     "OIDC",
     "queryjobs",
     "rawstring",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@types/lodash": "^4.17.0",
     "@types/node": "^20.8.7",
     "@types/react-router-dom": "^5.2.0",
-    "@types/testing-library__jest-dom": "6.0.0",
     "@typescript-eslint/eslint-plugin": "^8.34.1",
     "@typescript-eslint/parser": "^8.34.1",
     "copy-webpack-plugin": "^12.0.2",

--- a/pkg/humio/client_test.go
+++ b/pkg/humio/client_test.go
@@ -21,7 +21,7 @@ func TestClient(t *testing.T) {
 		defer teardownClientTest()
 		testMux.HandleFunc("/api/v1/repositories/repo/queryjobs", func(w http.ResponseWriter, req *http.Request) {
 			testMethod(t, req, http.MethodPost)
-			fmt.Fprint(w, `{"id":"testid"}`)
+			fmt.Fprint(w, `{"id":"testid"}`) //nolint:errcheck
 		})
 
 		id, err := testClient.CreateJob("repo", humio.Query{})
@@ -34,7 +34,7 @@ func TestClient(t *testing.T) {
 		defer teardownClientTest()
 		testMux.HandleFunc("/api/v1/repositories/repo/queryjobs/testid", func(w http.ResponseWriter, req *http.Request) {
 			testMethod(t, req, http.MethodDelete)
-			fmt.Fprint(w, "{}")
+			fmt.Fprint(w, "{}") //nolint:errcheck
 		})
 
 		err := testClient.DeleteJob("repo", "testid")
@@ -46,13 +46,14 @@ func TestClient(t *testing.T) {
 		defer teardownClientTest()
 		testMux.HandleFunc("/api/v1/repositories/repo/queryjobs/testid", func(w http.ResponseWriter, req *http.Request) {
 			testMethod(t, req, http.MethodGet)
-			fmt.Fprint(w, `{
+			cancelledRes := `{
 				"cancelled": false,
 				"done": false,
 				"events": [],
 				"metaData": {
 				}
-			}`)
+			}`
+			fmt.Fprint(w, cancelledRes) //nolint:errcheck
 		})
 
 		r, err := testClient.PollJob("repo", "testid")
@@ -67,14 +68,15 @@ func TestClient(t *testing.T) {
 		defer teardownClientTest()
 		testMux.HandleFunc("/graphql", func(w http.ResponseWriter, req *http.Request) {
 			testMethod(t, req, http.MethodPost)
-			fmt.Fprint(w, `{
+			listRes := `{
 				  "data": {
 				    "searchDomains": [
 							{ "name": "repo1" },
 							{ "name": "repo2" }
 						]
 				  }
-			}`)
+			}`
+			fmt.Fprint(w, listRes) //nolint:errcheck
 		})
 
 		r, err := testClient.ListRepos()
@@ -89,7 +91,7 @@ func TestClient(t *testing.T) {
 			tokenHeader := "Bearer testToken"
 			reqTokenHeader := req.Header.Get(backend.OAuthIdentityTokenHeaderName)
 			require.Equal(t, tokenHeader, reqTokenHeader)
-			fmt.Fprint(w, "{}")
+			fmt.Fprint(w, "{}") //nolint:errcheck
 		})
 		_, err := testClient.ListRepos()
 		require.Nil(t, err)
@@ -101,7 +103,7 @@ func TestClient(t *testing.T) {
 		testMux.HandleFunc("/api/v1/repositories/repo/queryjobs/stream", func(w http.ResponseWriter, req *http.Request) {
 			testMethod(t, req, http.MethodPost)
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"events": [{"message": "test event"}]}`)
+			fmt.Fprint(w, `{"events": [{"message": "test event"}]}`) //nolint:errcheck
 		})
 
 		ch := make(chan humio.StreamingResults)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3364,7 +3364,7 @@
     lz-string "^1.5.0"
     pretty-format "^27.0.2"
 
-"@testing-library/jest-dom@*", "@testing-library/jest-dom@6.4.2":
+"@testing-library/jest-dom@6.4.2":
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.4.2.tgz#38949f6b63722900e2d75ba3c6d9bf8cffb3300e"
   integrity sha512-CzqH0AFymEMG48CpzXFriYYkOjk6ZGPCLMhW9e9jg3KMCn5OfJecF8GtGW7yGfR/IgCe3SX8BSwjdzI6BBbZLw==
@@ -3706,13 +3706,6 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@types/string-hash/-/string-hash-1.1.3.tgz#8d9a73cf25574d45daf11e3ae2bf6b50e69aa212"
   integrity sha512-p6skq756fJWiA59g2Uss+cMl6tpoDGuCBuxG0SI1t0NwJmYOU66LAMS6QiCgu7cUh3/hYCaMl5phcCW1JP5wOA==
-
-"@types/testing-library__jest-dom@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-6.0.0.tgz#b558b64b80a72130714be1f505c6df482d453690"
-  integrity sha512-bnreXCgus6IIadyHNlN/oI5FfX4dWgvGhOPvpr7zzCYDGAPIfvyIoAozMBINmhmsVuqV0cncejF2y5KC7ScqOg==
-  dependencies:
-    "@testing-library/jest-dom" "*"
 
 "@types/tough-cookie@*":
   version "4.0.2"


### PR DESCRIPTION
According to Stack Overflow, to handle this error:

    error TS2688: Cannot find type definition file for 'testing-library__jest-dom'.

You need to do this:

    As of Aug 2023, if you are using the latest version of
    @testing-library/jest-dom, all you need to do is remove
    @types/testing-library_jest-dom.