### PR TITLE
Prepare 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.9.0
+
+- Feature: NGSIEM support. Read more about enabling NGSIEM support in Grafana here: [Falcon LogScale query editor](/docs/plugins/grafana-falconlogscale-datasource/latest/configure/)
+- Bump dependencies
+
 ## 1.8.6
 
 - Fix authentication switch bug [#682](https://github.com/grafana/falconlogscale-datasource/pull/682)
@@ -41,7 +46,7 @@
 
 ## 1.8.0
 
-- Feature: Tail live logs (Live query). Read more about Live querying in [Falcon LogScale query editor](/docs/plugins/grafana-falconlogscale-datasource/<FALCON_LOGSCALE_PLUGIN_VERSION>/editor/)
+- Feature: Tail live logs (Live query). Read more about Live querying in [Falcon LogScale query editor](/docs/plugins/grafana-falconlogscale-datasource/latest/editor/)
 - Dependency updates.
 
 ## 1.7.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-falconlogscale-datasource",
-  "version": "1.8.6",
+  "version": "1.9.0",
   "description": "Falcon LogScale data source plugin for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## 1.9.0

- Feature: NGSIEM support. Read more about enabling NGSIEM support in Grafana here: [Falcon LogScale query editor](/docs/plugins/grafana-falconlogscale-datasource/latest/configure/)
- Bump dependencies


Also fix broken link in change log