### PR TITLE
chore(ci): bump plugin-ci-workflows to ci-cd-workflows/v8.0.1 (GATB migration)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         environment: [dev, ops, prod]
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

Migrates this plugin's CI and CD workflows from `ci-cd-workflows/v7.3.1` to `ci-cd-workflows/v8.0.1`, the first release that requires short-lived [GATB-issued tokens](https://github.com/grafana/grafana-catalog-team/blob/main/docs/plugins-ci-github-actions/070-gatb-migration.md). The long-lived `grafana-plugins-platform-bot` token used by v7 will be revoked, so this bump is mandatory.

No other inputs need to change:
- All `github.com/grafana/*` modules in `go.mod` are public, so `go-private-git-auth` is not required.
- `release-please` and `version-bump-changelog` are not used.

## Notes

- v8 enables the Go race detector by default in CI. If any existing tests have data races they may start failing.
- Playwright e2e was bumped to v2.0.0 in v8 but both workflow calls pass `run-playwright: false`, so it's not in play here.